### PR TITLE
Modernize cmake

### DIFF
--- a/classes/CMakeLists.txt
+++ b/classes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12)
 project(classes)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -9,8 +9,7 @@ catkin_package(
     CATKIN_DEPENDS pybind11_catkin
 )
 
-include_directories(${PROJECT_SOURCE_DIR}/include
-                    ${catkin_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/include)
 
 
 pybind_add_module(dog MODULE src/dog.cpp src/cat.cpp)

--- a/cpp_object_attr/CMakeLists.txt
+++ b/cpp_object_attr/CMakeLists.txt
@@ -1,7 +1,5 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12)
 project(cpp_object_attr)
-
-find_package(PythonLibs REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
     pybind11_catkin)
@@ -13,12 +11,10 @@ catkin_package(
     CATKIN_DEPENDS pybind11_catkin
 )
 
-include_directories(${PYTHON_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
-
 pybind_add_module(cpp_object MODULE src/cpp_object.cpp)
-pybind_add_module(example SHARED src/example.cpp )
+pybind_add_module(example SHARED src/example.cpp)
 add_executable(main src/main.cpp)
-target_link_libraries(main ${PYTHON_LIBRARIES} example)
+target_link_libraries(main example pybind11::embed)
 
 install(TARGETS main
                 cpp_object

--- a/cpp_object_attr/src/main.cpp
+++ b/cpp_object_attr/src/main.cpp
@@ -1,7 +1,7 @@
 #include "example.cpp"
 
-int main(int argc, char **argv) {
+int main(int /*argc*/, char ** /*argv*/)
+{
     example();
     return 0;
 }
-

--- a/function_call/CMakeLists.txt
+++ b/function_call/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12)
 project(function_call)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -8,8 +8,6 @@ catkin_package(
     LIBRARIES
     CATKIN_DEPENDS pybind11_catkin
 )
-
-include_directories(${catkin_INCLUDE_DIRS})
 
 pybind_add_module(logger MODULE src/logger.cpp)
 

--- a/inheritance/CMakeLists.txt
+++ b/inheritance/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12)
 project(inheritance)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -9,8 +9,7 @@ catkin_package(
     CATKIN_DEPENDS pybind11_catkin
 )
 
-include_directories(${PROJECT_SOURCE_DIR}/include
-                    ${catkin_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/include)
 
 pybind_add_module(pet MODULE src/pet.cpp)
 

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.12)
 project(plugin)
 add_compile_options(-Wno-attributes -std=c++11)
-
-find_package(PythonLibs REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
     pybind11_catkin)
@@ -14,18 +12,16 @@ catkin_package(
     CATKIN_DEPENDS pybind11_catkin
 )
 
-include_directories(${PROJECT_SOURCE_DIR}/include
-                    ${PYTHON_INCLUDE_DIRS}
-                    ${catkin_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/include)
 
 add_library(base_plugin SHARED src/base_plugin.cpp)
 add_library(plugin_wrapper SHARED src/plugin_wrapper.cpp)
-target_link_libraries(plugin_wrapper ${PYTHON_LIBRARIES} base_plugin)
+target_link_libraries(plugin_wrapper base_plugin pybind11::embed)
 
 pybind_add_module(py_base_plugin MODULE src/py_base_plugin.cpp)
 
 add_executable(plugin_runner src/plugin_runner.cpp)
-target_link_libraries(plugin_runner ${PYTHON_LIBRARIES} base_plugin plugin_wrapper)
+target_link_libraries(plugin_runner base_plugin plugin_wrapper)
 
 install(TARGETS plugin_runner
                 base_plugin

--- a/plugin/src/plugin_runner.cpp
+++ b/plugin/src/plugin_runner.cpp
@@ -21,8 +21,8 @@ void PluginRunner::run()
     }
 }
 
-
-int main(int argc, char **argv) {
+int main(int /*argc*/, char ** /*argv*/)
+{
     PluginRunner plugin_runner;
     plugin_runner.add(new PluginWrapper("plugin.custom_plugin", "CustomPlugin"));
     plugin_runner.run();


### PR DESCRIPTION
- Avoid using `include_directories`
- No need to find_package PythonLibs
- Use pybind11::* targets

Depends on:
- [ ] https://github.com/wxmerkt/pybind11_catkin/pull/27